### PR TITLE
Fix adventureworks SpecialOfferProduct CSV import

### DIFF
--- a/adventureworks/install.sql
+++ b/adventureworks/install.sql
@@ -1230,7 +1230,7 @@ SELECT 'Copying data into Sales.ShoppingCartItem';
 SELECT 'Copying data into Sales.SpecialOffer';
 \copy Sales.SpecialOffer FROM './data/SpecialOffer.csv' DELIMITER E'\t' CSV;
 SELECT 'Copying data into Sales.SpecialOfferProduct';
-\copy Sales.SpecialOfferProduct FROM 'SpecialOfferProduct.csv' DELIMITER E'\t' CSV;
+\copy Sales.SpecialOfferProduct FROM './data/SpecialOfferProduct.csv' DELIMITER E'\t' CSV;
 SELECT 'Copying data into Sales.Store';
 \copy Sales.Store FROM './data/Store.csv' DELIMITER E'\t' CSV;
 


### PR DESCRIPTION
A `psql -d Adventureworks < install.sql` was failing with:

```
│ Copying data into Sales.SpecialOfferProduct │
└─────────────────────────────────────────────┘

SpecialOfferProduct.csv: No such file or directory
│ Copying data into Sales.Store │
└───────────────────────────────┘

ERROR:  insert or update on table "salesorderdetail" violates foreign key constraint "FK_SalesOrderDetail_SpecialOfferProduct_SpecialOfferIDProductID"
DETAIL:  Key (specialofferid, productid)=(1, 776) is not present in table "specialofferproduct".
```

The corresponding file path in `install.sql` was only missing the `./data/` subdirectory prefix:

```
\copy Sales.SpecialOfferProduct FROM 'SpecialOfferProduct.csv' DELIMITER E'\t' CSV;
```
instead of:
```
\copy Sales.SpecialOfferProduct FROM './data/SpecialOfferProduct.csv' DELIMITER E'\t' CSV;
```